### PR TITLE
[Design] 글로벌 스타일 생성 및 CSS 리셋

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,0 +1,153 @@
+@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css");
+
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  vertical-align: baseline;
+}
+/* HTML5 display-role reset for older browsers */
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
+}
+body {
+  line-height: 1;
+}
+ol,
+ul {
+  list-style: none;
+}
+blockquote,
+q {
+  quotes: none;
+}
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
+}
+table {
+  border-collapse: collapse;
+  border: 0;
+}
+button {
+  cursor: pointer;
+}
+*,
+*::after,
+*::before {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+html {
+  font-size: 16 px;
+  font-family:
+    "Pretendard Variable",
+    Pretendard,
+    -apple-system,
+    BlinkMacSystemFont,
+    system-ui,
+    Roboto,
+    "Helvetica Neue",
+    "Segoe UI",
+    "Apple SD Gothic Neo",
+    "Noto Sans KR",
+    "Malgun Gothic",
+    "Apple Color Emoji",
+    "Segoe UI Emoji",
+    "Segoe UI Symbol",
+    sans-serif;
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,4 +1,4 @@
-@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css");
+@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css");
 
 html,
 body,

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,3 +1,4 @@
+import "./globals.css";
 import Provider from "../app/Provider";
 
 export const metadata = {

--- a/packages/ui/.eslintrc.js
+++ b/packages/ui/.eslintrc.js
@@ -5,5 +5,7 @@ module.exports = {
   parser: "@typescript-eslint/parser",
   parserOptions: {
     project: "./tsconfig.lint.json",
+    tsconfigRootDir: __dirname,
+    sourceType: "module",
   },
 };

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,7 +5,8 @@
   "exports": {
     "./button": "./src/button.tsx",
     "./card": "./src/card.tsx",
-    "./code": "./src/code.tsx"
+    "./code": "./src/code.tsx",
+    "./common": "./src/common.ts"
   },
   "scripts": {
     "lint": "eslint . --max-warnings 0",

--- a/packages/ui/src/common.ts
+++ b/packages/ui/src/common.ts
@@ -1,0 +1,165 @@
+export const Common = {
+  a11yHidden: `
+  overflow: hidden;
+  position: absolute !important;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  `,
+  reset: `
+    @import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css');
+    html,
+    body,
+    div,
+    span,
+    applet,
+    object,
+    iframe,
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    p,
+    blockquote,
+    pre,
+    a,
+    abbr,
+    acronym,
+    address,
+    big,
+    cite,
+    code,
+    del,
+    dfn,
+    em,
+    img,
+    ins,
+    kbd,
+    q,
+    s,
+    samp,
+    small,
+    strike,
+    strong,
+    sub,
+    sup,
+    tt,
+    var,
+    b,
+    u,
+    i,
+    center,
+    dl,
+    dt,
+    dd,
+    ol,
+    ul,
+    li,
+    fieldset,
+    form,
+    label,
+    legend,
+    table,
+    caption,
+    tbody,
+    tfoot,
+    thead,
+    tr,
+    th,
+    td,
+    article,
+    aside,
+    canvas,
+    details,
+    embed,
+    figure,
+    figcaption,
+    footer,
+    header,
+    hgroup,
+    menu,
+    nav,
+    output,
+    ruby,
+    section,
+    summary,
+    time,
+    mark,
+    audio,
+    video {
+      margin: 0;
+      padding: 0;
+      border: 0;
+      vertical-align: baseline;
+    }
+    /* HTML5 display-role reset for older browsers */
+    article,
+    aside,
+    details,
+    figcaption,
+    figure,
+    footer,
+    header,
+    hgroup,
+    menu,
+    nav,
+    section {
+      display: block;
+    }
+    body {
+      line-height: 1;
+    }
+    ol,
+    ul {
+      list-style: none;
+    }
+    blockquote,
+    q {
+      quotes: none;
+    }
+    blockquote:before,
+    blockquote:after,
+    q:before,
+    q:after {
+      content: "";
+      content: none;
+    }
+    table {
+      border-collapse: collapse;
+      border-: 0;
+    }
+    button {
+      cursor: pointer;
+    }
+    *,
+    *::after,
+    *::before {
+      box-sizing: border-box;
+      -moz-osx-font-smoothing: grayscale;
+      -webkit-font-smoothing: antialiased;
+    }
+    html {
+      font-size: 16 px;
+      font-family:
+        "Pretendard Variable",
+        Pretendard,
+        -apple-system,
+        BlinkMacSystemFont,
+        system-ui,
+        Roboto,
+        "Helvetica Neue",
+        "Segoe UI",
+        "Apple SD Gothic Neo",
+        "Noto Sans KR",
+        "Malgun Gothic",
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        sans-serif;
+    }
+  `,
+};


### PR DESCRIPTION
<!--
1. 제목은 50자 이내
2. 장황하게 설명하지 않고 간단하게 기술
3. 과거 시제 사용 X
4. 명사형 어미 사용

* 제목양식
[태그] 제목 #이슈번호
태그 첫 글자는 대문자로
예시) [Feat] 로그인 기능 구현 #32

* 제목 태그 종류
[Feat] 새로운 기능 추가
[Fix] 버그 수정
[Docs] 문서 수정
[Style] 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
[Design] CSS 등 사용자 UI 디자인 변경
[Refactor] 코드 리팩토링
[Test] 테스트 코드, 리팩토링 테스트 코드 추가
[Chore] 빌드 업무 수정, 패키지 매니저 수정


* 작성 후 이슈, 라벨, 마일스톤 등 연결하기
* Assignees : 작업자
-->

## 작업사항

<!-- 작업한 내용 작성 -->

- apps/web/app/globals.css 내부 css 초기화 코드 작성
- css 초기화와 함께 pretendard 폰트 html 기본 폰트로 세팅
- packages/ui/src/common.ts 내부 프로젝트 전체에서 사용할 수 있는 공통 스타일 구성 시도
 - 패키지(web or docs)내부에서 import 후 적용 문제로 실패
 - 추후 조사 및 해결 후 사용을 위해 파일은 남겨둠

## 미리보기 및 사용방법

<!-- 미리보기 파일 첨부와 함께 사용 방법 작성. 이미지, 동영상 등 작업 내용을 확인할 수 있는 파일 첨부 -->
<img width="1675" alt="Screenshot 2024-01-21 at 7 11 41 PM" src="https://github.com/33-ohoh/33-ohoh/assets/69342971/70bd9d8b-7ded-4271-b238-9e970ca5496d">

## 기타

<!-- 필요한 경우 작성 -->
- styleX를 사용한 css 리셋 코드 작성또한 시도했으나 StyleX의 정적 스타일 규칙 요구사항과 충돌로 보이는 문제로 인해 실패.
  - 현재의 형태와 같은 css 리셋 및 공통 스타일 생성 방식이 적절한 지에 대해서 논의 필요.

- 디자인 팀에서 전달될 예정인 디자인 시스템 적용 방안에 대해서는 추후 조사 예정.

## 작성일

<!-- 풀 리퀘스트 작성한 날짜 작성 yyyy.mm.dd -->

2024.01.21
