### PR TITLE
[Fix] global.css 때문에 컴포넌트 내부 스타일이 제대로 적용되지 않는 문제 해결 #20

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,153 +1,155 @@
 @import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css");
 
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  vertical-align: baseline;
-}
-/* HTML5 display-role reset for older browsers */
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-menu,
-nav,
-section {
-  display: block;
-}
-body {
-  line-height: 1;
-}
-ol,
-ul {
-  list-style: none;
-}
-blockquote,
-q {
-  quotes: none;
-}
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-  content: "";
-  content: none;
-}
-table {
-  border-collapse: collapse;
-  border: 0;
-}
-button {
-  cursor: pointer;
-}
-*,
-*::after,
-*::before {
-  box-sizing: border-box;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-html {
-  font-size: 16 px;
-  font-family:
-    "Pretendard Variable",
-    Pretendard,
-    -apple-system,
-    BlinkMacSystemFont,
-    system-ui,
-    Roboto,
-    "Helvetica Neue",
-    "Segoe UI",
-    "Apple SD Gothic Neo",
-    "Noto Sans KR",
-    "Malgun Gothic",
-    "Apple Color Emoji",
-    "Segoe UI Emoji",
-    "Segoe UI Symbol",
-    sans-serif;
+@layer reset {
+  html,
+  body,
+  div,
+  span,
+  applet,
+  object,
+  iframe,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  p,
+  blockquote,
+  pre,
+  a,
+  abbr,
+  acronym,
+  address,
+  big,
+  cite,
+  code,
+  del,
+  dfn,
+  em,
+  img,
+  ins,
+  kbd,
+  q,
+  s,
+  samp,
+  small,
+  strike,
+  strong,
+  sub,
+  sup,
+  tt,
+  var,
+  b,
+  u,
+  i,
+  center,
+  dl,
+  dt,
+  dd,
+  ol,
+  ul,
+  li,
+  fieldset,
+  form,
+  label,
+  legend,
+  table,
+  caption,
+  tbody,
+  tfoot,
+  thead,
+  tr,
+  th,
+  td,
+  article,
+  aside,
+  canvas,
+  details,
+  embed,
+  figure,
+  figcaption,
+  footer,
+  header,
+  hgroup,
+  menu,
+  nav,
+  output,
+  ruby,
+  section,
+  summary,
+  time,
+  mark,
+  audio,
+  video {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    vertical-align: baseline;
+  }
+  /* HTML5 display-role reset for older browsers */
+  article,
+  aside,
+  details,
+  figcaption,
+  figure,
+  footer,
+  header,
+  hgroup,
+  menu,
+  nav,
+  section {
+    display: block;
+  }
+  body {
+    line-height: 1;
+  }
+  ol,
+  ul {
+    list-style: none;
+  }
+  blockquote,
+  q {
+    quotes: none;
+  }
+  blockquote:before,
+  blockquote:after,
+  q:before,
+  q:after {
+    content: "";
+    content: none;
+  }
+  table {
+    border-collapse: collapse;
+    border: 0;
+  }
+  button {
+    cursor: pointer;
+  }
+  *,
+  *::after,
+  *::before {
+    box-sizing: border-box;
+    -moz-osx-font-smoothing: grayscale;
+    -webkit-font-smoothing: antialiased;
+  }
+  html {
+    font-size: 16 px;
+    font-family:
+      "Pretendard Variable",
+      Pretendard,
+      -apple-system,
+      BlinkMacSystemFont,
+      system-ui,
+      Roboto,
+      "Helvetica Neue",
+      "Segoe UI",
+      "Apple SD Gothic Neo",
+      "Noto Sans KR",
+      "Malgun Gothic",
+      "Apple Color Emoji",
+      "Segoe UI Emoji",
+      "Segoe UI Symbol",
+      sans-serif;
+  }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,44 +1,44 @@
 {
-	"name": "@repo/ui",
-	"version": "0.0.0",
-	"private": true,
-	"exports": {
-		"./button": "./src/button.tsx",
-		"./card": "./src/card.tsx",
-		"./code": "./src/code.tsx",
-		"./common": "./src/common.ts",
-		"./quillEditor": "./src/quillEditor.tsx",
-		"./hotLogcard": "./src/main/hotLogCard.tsx",
-		"./hotLogList": "./src/main/hotLogList.tsx",
-		"./hotLogSection": "./src/main/hotLogSection.tsx",
-		"./designToken": "./src/designToken.stylex.ts",
-		"./icon": "./src/icon.tsx",
-		"./asideContainer": "./src/mypage/asideContainer.tsx",
-		"./mainContainer": "./src/mypage/mainContainer.tsx",
-	},
-	"scripts": {
-		"lint": "eslint . --max-warnings 0",
-		"generate:component": "turbo gen react-component"
-	},
-	"devDependencies": {
-		"@repo/eslint-config": "*",
-		"@repo/typescript-config": "*",
-		"@stylexjs/babel-plugin": "^0.4.1",
-		"@stylexjs/eslint-plugin": "^0.4.1",
-		"@stylexjs/nextjs-plugin": "^0.4.1",
-		"@turbo/gen": "^1.11.3",
-		"@types/eslint": "^8.56.1",
-		"@types/node": "^20.10.6",
-		"@types/quill": "^2.0.14",
-		"@types/react": "^18.2.46",
-		"@types/react-dom": "^18.2.18",
-		"eslint": "^8.56.0",
-		"react": "^18.2.0",
-		"typescript": "^5.3.3"
-	},
-	"dependencies": {
-		"quill": "^1.3.7",
-		"react-quill": "^2.0.0",
-		"@stylexjs/stylex": "^0.4.1"
-	}
+  "name": "@repo/ui",
+  "version": "0.0.0",
+  "private": true,
+  "exports": {
+    "./button": "./src/button.tsx",
+    "./card": "./src/card.tsx",
+    "./code": "./src/code.tsx",
+    "./common": "./src/common.ts",
+    "./quillEditor": "./src/quillEditor.tsx",
+    "./hotLogcard": "./src/main/hotLogCard.tsx",
+    "./hotLogList": "./src/main/hotLogList.tsx",
+    "./hotLogSection": "./src/main/hotLogSection.tsx",
+    "./designToken": "./src/designToken.stylex.ts",
+    "./icon": "./src/icon.tsx",
+    "./asideContainer": "./src/mypage/asideContainer.tsx",
+    "./mainContainer": "./src/mypage/mainContainer.tsx"
+  },
+  "scripts": {
+    "lint": "eslint . --max-warnings 0",
+    "generate:component": "turbo gen react-component"
+  },
+  "devDependencies": {
+    "@repo/eslint-config": "*",
+    "@repo/typescript-config": "*",
+    "@stylexjs/babel-plugin": "^0.4.1",
+    "@stylexjs/eslint-plugin": "^0.4.1",
+    "@stylexjs/nextjs-plugin": "^0.4.1",
+    "@turbo/gen": "^1.11.3",
+    "@types/eslint": "^8.56.1",
+    "@types/node": "^20.10.6",
+    "@types/quill": "^2.0.14",
+    "@types/react": "^18.2.46",
+    "@types/react-dom": "^18.2.18",
+    "eslint": "^8.56.0",
+    "react": "^18.2.0",
+    "typescript": "^5.3.3"
+  },
+  "dependencies": {
+    "quill": "^1.3.7",
+    "react-quill": "^2.0.0",
+    "@stylexjs/stylex": "^0.4.1"
+  }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -15,7 +15,6 @@
 		"./icon": "./src/icon.tsx",
 		"./asideContainer": "./src/mypage/asideContainer.tsx",
 		"./mainContainer": "./src/mypage/mainContainer.tsx",
-		"./designToken": "./src/designToken.stylex.ts"
 	},
 	"scripts": {
 		"lint": "eslint . --max-warnings 0",


### PR DESCRIPTION
<!--
1. 제목은 50자 이내
2. 장황하게 설명하지 않고 간단하게 기술
3. 과거 시제 사용 X
4. 명사형 어미 사용

* 제목양식
[태그] 제목 #이슈번호
태그 첫 글자는 대문자로
예시) [Feat] 로그인 기능 구현 #32

* 제목 태그 종류
[Feat] 새로운 기능 추가
[Fix] 버그 수정
[Docs] 문서 수정
[Style] 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
[Design] CSS 등 사용자 UI 디자인 변경
[Refactor] 코드 리팩토링
[Test] 테스트 코드, 리팩토링 테스트 코드 추가
[Chore] 빌드 업무 수정, 패키지 매니저 수정


* 작성 후 이슈, 라벨, 마일스톤 등 연결하기
* Assignees : 작업자
-->

## 작업사항

<!-- 작업한 내용 작성 -->

- apps/web/app/globals.css 내부의 css 리셋 코드를 @layer reset 으로 묶음.

## 미리보기 및 사용방법

<!-- 미리보기 파일 첨부와 함께 사용 방법 작성. 이미지, 동영상 등 작업 내용을 확인할 수 있는 파일 첨부 -->
```
@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css");

@layer reset {
  html,
  body,
  div,
  span,
  applet,
  object,
  iframe,
  h1,
  h2,
  h3,
  h4,
  h5,
  h6,
  p,
  blockquote,
  pre,
  a,
  abbr,
  acronym,
  address,
  big,
  cite,
  code,
  del,
  dfn,
  em,
  img,
  ins,
  kbd,
  q,
  s,
  samp,
  small,
  strike,
  strong,
  sub,
  sup,
  tt,
  var,
  b,
  u,
  i,
  center,
  dl,
  dt,
  dd,
  ol,
  ul,
  li,
  fieldset,
  form,
  label,
  legend,
  table,
  caption,
  tbody,
  tfoot,
  thead,
  tr,
  th,
  td,
  article,
  aside,
  canvas,
  details,
  embed,
  figure,
  figcaption,
  footer,
  header,
  hgroup,
  menu,
  nav,
  output,
  ruby,
  section,
  summary,
  time,
  mark,
  audio,
  video {
    margin: 0;
    padding: 0;
    border: 0;
    vertical-align: baseline;
  }
...
(생략)
}

```
## 기타

<!-- 필요한 경우 작성 -->
- 이미 스타일링된 다른 컴포넌트에서 문제가 없는지 확인해야 함.
## 작성일

<!-- 풀 리퀘스트 작성한 날짜 작성 yyyy.mm.dd -->

2024.01.25
