### PR TITLE
[Feat] 로그인 회원가입 비밀번호찾기 회원 탈퇴의 로직 구현 #10

### DIFF
--- a/apps/web/apis/auth.ts
+++ b/apps/web/apis/auth.ts
@@ -1,0 +1,209 @@
+import type {
+  LoginFormData,
+  LoginResponse,
+  signupFormData,
+} from "../types/auth";
+import type { ErrorResponse, ListResponse } from "../types/response";
+import { User } from "../types/user";
+import fetcher from "../utils/fetcher";
+
+/* eslint-disable turbo/no-undeclared-env-vars */
+const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+const adminApiUrl = process.env.NEXT_PUBLIC_ADMIN_API_URL;
+const adminEmail = process.env.NEXT_PUBLIC_ADMIN_EMAIL;
+const adminPassword = process.env.NEXT_PUBLIC_ADMIN_PASSWORD;
+
+export const authenticateAdminWithPassword = async (): Promise<
+  LoginResponse | ErrorResponse | null
+> => {
+  try {
+    const response = await fetcher<LoginResponse>(
+      `${adminApiUrl}/auth-with-password`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ identity: adminEmail, password: adminPassword }),
+      },
+    );
+    return response;
+  } catch (error: any) {
+    console.error("authenticateWithPassword error:", error.message);
+    throw error;
+  }
+};
+
+export const authenticateWithPassword = async ({
+  identity,
+  password,
+}: LoginFormData): Promise<LoginResponse | ErrorResponse | null> => {
+  try {
+    const response = await fetcher<LoginResponse>(
+      `${apiUrl}/users/auth-with-password`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ identity, password }),
+      },
+    );
+    return response;
+  } catch (error: any) {
+    console.error("authenticateWithPassword error:", error.message);
+    throw error;
+  }
+};
+
+export const getUsersByFields = async (
+  key: string,
+  value: string,
+): Promise<ListResponse<User> | ErrorResponse | null> => {
+  try {
+    const response = await fetcher<ListResponse<User>>(
+      `${apiUrl}/users/records?filter=(${key}=%27${value}%27)`,
+      {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      },
+    );
+    return response;
+  } catch (error: any) {
+    console.error("getUsers error:", error.message);
+    throw error;
+  }
+};
+
+export const createUser = async (
+  {
+    name,
+    username,
+    email,
+    password,
+    passwordConfirm,
+    emailVisibility,
+  }: signupFormData,
+  token: string,
+) => {
+  try {
+    const response = await fetcher<User>(`${apiUrl}/users/records`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        name,
+        username,
+        email,
+        password,
+        passwordConfirm,
+        emailVisibility,
+      }),
+    });
+
+    return response;
+  } catch (error: any) {
+    console.error("createUser error:", error.message);
+    throw error;
+  }
+};
+
+export const updateUser = async (id: string, userData: User, token: string) => {
+  try {
+    const response = await fetcher<User>(`${apiUrl}/users/records${id}`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(userData),
+    });
+    return response;
+  } catch (error: any) {
+    console.error("updateLog error:", error.message);
+    throw error;
+  }
+};
+
+export const usernameDoubleCheck = async (username: string) => {
+  try {
+    const response = await fetcher<ListResponse<User>>(
+      `${apiUrl}/users/records?filter=(username='${username}')`,
+      {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      },
+    );
+    return response;
+  } catch (error: any) {
+    console.error("createUser error:", error.message);
+    throw error;
+  }
+};
+
+export const requestVerification = async (
+  email: string,
+): Promise<ErrorResponse | null> => {
+  try {
+    const response = await fetcher<null>(
+      `${apiUrl}/users/request-verification`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ email }),
+      },
+    );
+    return response;
+  } catch (error: any) {
+    console.error("requestVerification error:", error.message);
+    throw error;
+  }
+};
+
+export const requestPasswordReset = async (
+  email: string,
+): Promise<ErrorResponse | null> => {
+  try {
+    const response = await fetcher<null>(
+      `${apiUrl}/users/request-password-reset`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ email }),
+      },
+    );
+    return response;
+  } catch (error: any) {
+    console.error("requestPasswordReset error:", error.message);
+    throw error;
+  }
+};
+
+export const deleteUser = async (
+  id: string,
+  token: string,
+): Promise<ErrorResponse | null> => {
+  try {
+    const response = await fetcher<null>(`${apiUrl}/users/records/${id}`, {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    return response;
+  } catch (error: any) {
+    console.error("requestPasswordReset error:", error.message);
+    throw error;
+  }
+};

--- a/apps/web/apis/log.ts
+++ b/apps/web/apis/log.ts
@@ -1,9 +1,12 @@
-import type { Log, LogsResponse } from "../types/log";
+import type { Log } from "../types/log";
+import type { ErrorResponse, ListResponse } from "../types/response";
 import fetcher from "../utils/fetcher";
 
-export const getLogs = async (url: string): Promise<LogsResponse | null> => {
+export const getLogs = async (
+  url: string,
+): Promise<ListResponse<Log> | ErrorResponse | null> => {
   try {
-    const response = await fetcher<LogsResponse>(url, {
+    const response = await fetcher<ListResponse<Log>>(url, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
@@ -16,7 +19,9 @@ export const getLogs = async (url: string): Promise<LogsResponse | null> => {
   }
 };
 
-export const getLog = async (url: string): Promise<Log | null> => {
+export const getLog = async (
+  url: string,
+): Promise<Log | ErrorResponse | null> => {
   try {
     const response = await fetcher<Log>(url, {
       method: "GET",
@@ -34,7 +39,7 @@ export const getLog = async (url: string): Promise<Log | null> => {
 export const createLog = async (
   url: string,
   { arg: { logData, token } }: { arg: { logData: Log; token: string } },
-): Promise<Log | null> => {
+): Promise<Log | ErrorResponse | null> => {
   try {
     const response = await fetcher<Log>(url, {
       method: "POST",

--- a/apps/web/app/find-password/page.tsx
+++ b/apps/web/app/find-password/page.tsx
@@ -1,7 +1,15 @@
-import React from "react";
+"use client";
+import { useState } from "react";
+import ChangePasswordForm from "../../components/find-password/ChangePasswordForm";
+import FindPasswordForm from "../../components/find-password/FindPasswordForm";
 
 const Page = () => {
-  return <div>FindPassword</div>;
+  const [isVerified, setIsVerified] = useState(false);
+  return isVerified ? (
+    <ChangePasswordForm />
+  ) : (
+    <FindPasswordForm setIsVerified={setIsVerified} />
+  );
 };
 
 export default Page;

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -1,5 +1,104 @@
-const Page = () => {
-  return <div>Login</div>;
+"use client";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+import { authenticateWithPassword } from "../../apis/auth";
+import { useAppDispatch, useAppSelector } from "../../hooks/redux";
+import { setLoginData } from "../../store/loginSlice";
+import type { LoginFormData, LoginResponse } from "../../types/auth";
+import withAuth from "../../utils/withAuth";
+
+const Login = () => {
+  const dispatch = useAppDispatch();
+  const loginState = useAppSelector((state) => state.login);
+  const router = useRouter();
+
+  const loginHandler = async () => {
+    const loginData: LoginFormData = {
+      identity: loginState.email,
+      password: loginState.password,
+    };
+    try {
+      const response = await authenticateWithPassword(loginData);
+
+      if (response && "token" in response) {
+        const token = (response as LoginResponse).token;
+        const expiresIn = 3600;
+        const expirationTime = new Date().getTime() + expiresIn * 1000;
+        sessionStorage.setItem("token", token);
+        sessionStorage.setItem("tokenExpiration", expirationTime.toString());
+      }
+
+      if (loginState.rememberUser) {
+        localStorage.setItem("savedEmail", loginState.email);
+      } else {
+        localStorage.removeItem("savedEmail");
+      }
+
+      router.replace("/");
+    } catch (error: any) {
+      alert("로그인 실패");
+    }
+  };
+
+  useEffect(() => {
+    const storedEmail = localStorage.getItem("savedEmail");
+    if (storedEmail) {
+      dispatch(setLoginData({ email: storedEmail }));
+      dispatch(setLoginData({ rememberUser: true }));
+    }
+  }, []);
+
+  return (
+    <div>
+      <h1>Login</h1>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          loginHandler();
+        }}
+      >
+        <input
+          className="border border-gray-400"
+          type="email"
+          value={loginState.email}
+          onChange={(e) => dispatch(setLoginData({ email: e.target.value }))}
+        />
+
+        <label>Password:</label>
+        <input
+          className="border border-gray-400"
+          type="password"
+          value={loginState.password}
+          onChange={(e) => dispatch(setLoginData({ password: e.target.value }))}
+        />
+
+        <label>로그인 정보 저장</label>
+        <input
+          checked={loginState.rememberUser}
+          onChange={() =>
+            dispatch(setLoginData({ rememberUser: !loginState.rememberUser }))
+          }
+          type="checkbox"
+        />
+        <button type="submit">Login</button>
+      </form>
+
+      <div
+        style={{
+          width: "664px",
+          display: "flex",
+          justifyContent: "space-between",
+        }}
+      >
+        <Link href={"signup"}>회원가입하기</Link>
+
+        <div>
+          <Link href={"find-password"}>비밀번호 찾기</Link>
+        </div>
+      </div>
+    </div>
+  );
 };
 
-export default Page;
+export default withAuth(Login);

--- a/apps/web/app/signup/page.tsx
+++ b/apps/web/app/signup/page.tsx
@@ -1,7 +1,41 @@
-import React from "react";
+"use client";
+import InterestAndPrivacyForm from "../../components/signup/InterestAndPrivacyForm";
+import SignupForm from "../../components/signup/SignupForm";
+import SignUpSuccess from "../../components/signup/SignUpSuccess";
+import SignupTerm from "../../components/signup/SignupTerm";
 
-const Page = () => {
-  return <div>Signup</div>;
+import { useState } from "react";
+import withAuth from "../../utils/withAuth";
+
+const Signup = () => {
+  const [step, setStep] = useState(1);
+  let currentPage = <SignupTerm setStep={setStep} />;
+
+  switch (step) {
+    case 1:
+      currentPage = <SignupTerm setStep={setStep} />;
+      break;
+    case 2:
+      currentPage = <SignupForm setStep={setStep} />;
+      break;
+    case 3:
+      currentPage = <InterestAndPrivacyForm setStep={setStep} />;
+      break;
+    case 4:
+      currentPage = <SignUpSuccess />;
+      break;
+    default:
+      currentPage = <SignupTerm setStep={setStep} />;
+      break;
+  }
+
+  return (
+    <>
+      <h1>signup</h1>
+      {step !== 4 && <div>stepper</div>}
+      {currentPage}
+    </>
+  );
 };
 
-export default Page;
+export default withAuth(Signup);

--- a/apps/web/components/find-password/ChangePasswordForm.tsx
+++ b/apps/web/components/find-password/ChangePasswordForm.tsx
@@ -1,0 +1,34 @@
+"use client";
+import { useRouter } from "next/navigation";
+import { requestPasswordReset } from "../../apis/auth";
+import { useAppDispatch } from "../../hooks/redux";
+import { logout } from "../../store/loginSlice";
+
+const ChangePasswordForm = () => {
+  const dispatch = useAppDispatch();
+  const router = useRouter();
+
+  const requestPasswordResetHandler = async () => {
+    const email = "recomplete@naver.com";
+    const response = await requestPasswordReset(email);
+    if (response === null) {
+      dispatch(logout());
+      alert("비밀번호가 변경되었습니다. 다시 로그인해주세요.");
+      router.replace("/login");
+    }
+  };
+  return (
+    <div>
+      <h1>비밀번호변경하기</h1>
+      <label>새 비밀번호</label>
+      <input className="border border-gray-400" type="text" />
+      <label>새 비밀번호 확인</label>
+      <input className="border border-gray-400" type="text" />
+      <div>
+        <button onClick={requestPasswordResetHandler}>완료</button>
+      </div>
+    </div>
+  );
+};
+
+export default ChangePasswordForm;

--- a/apps/web/components/find-password/FindPasswordForm.tsx
+++ b/apps/web/components/find-password/FindPasswordForm.tsx
@@ -1,0 +1,99 @@
+"use client";
+import { Dispatch, SetStateAction, useState } from "react";
+import { getUsersByFields, requestVerification } from "../../apis/auth";
+
+interface FindPasswordFormProps {
+  setIsVerified: Dispatch<SetStateAction<boolean>>;
+}
+const FindPasswordForm = ({ setIsVerified }: FindPasswordFormProps) => {
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [emailVerification, setEmailVerification] = useState("Unverified");
+
+  const requestVerificationHandler = async () => {
+    const nameResponse = await getUsersByFields("name", name);
+
+    if (
+      nameResponse &&
+      "items" in nameResponse &&
+      nameResponse.items.length !== 0
+    ) {
+      const emailResponse = await requestVerification(email);
+
+      if (emailResponse === null) {
+        setEmailVerification("InProgress");
+        alert("인증 메일을 발송하였습니다.");
+      }
+    } else {
+      alert("존재하지 않는 회원입니다.");
+    }
+  };
+
+  const emailVerificationCheckHandler = async () => {
+    const nameResponse = await getUsersByFields("name", name);
+    if (
+      nameResponse &&
+      "items" in nameResponse &&
+      nameResponse.items.length !== 0
+    ) {
+      const user = nameResponse.items[0];
+      if (user?.verified) {
+        setEmailVerification("Verified");
+        alert("인증이 완료된 이메일 입니다.");
+      } else {
+        const emailResponse = await requestVerification(email);
+
+        if (emailResponse === null) {
+          setEmailVerification("InProgress");
+          alert("인증 메일을 발송하였습니다.");
+        }
+      }
+    }
+  };
+
+  const nameChangeHandler = (e: any) => {
+    setName(e.target.value);
+  };
+
+  const emailChangeHandler = (e: any) => {
+    setEmail(e.target.value);
+  };
+  return (
+    <div>
+      <h1>비밀번호찾기</h1>
+      <label>이름</label>
+      <input
+        onChange={nameChangeHandler}
+        className="border border-gray-400"
+        type="text"
+      />
+
+      <label>이메일 인증</label>
+      <input
+        onChange={emailChangeHandler}
+        className="border border-gray-400"
+        type="text"
+      />
+
+      <button
+        disabled={emailVerification === "Verified"}
+        onClick={requestVerificationHandler}
+      >
+        {emailVerification === "Unverified" ? "인증요청" : "인증확인"}
+      </button>
+
+      <button
+        disabled={emailVerification === "Verified"}
+        onClick={emailVerificationCheckHandler}
+      >
+        {"인증확인"}
+      </button>
+
+      <div>
+        <button onClick={() => setIsVerified(true)}>다음</button>
+      </div>
+    </div>
+  );
+};
+
+export default FindPasswordForm;

--- a/apps/web/components/signup/InterestAndPrivacyForm.tsx
+++ b/apps/web/components/signup/InterestAndPrivacyForm.tsx
@@ -1,0 +1,143 @@
+import type { Dispatch, SetStateAction } from "react";
+import { useAppDispatch, useAppSelector } from "../../hooks/redux";
+import { setSignupData } from "../../store/signupSlice";
+
+interface InterestAndPrivacyFormProps {
+  setStep: Dispatch<SetStateAction<number>>;
+}
+
+const InterestAndPrivacyForm = ({ setStep }: InterestAndPrivacyFormProps) => {
+  const dispatch = useAppDispatch();
+  const signupState = useAppSelector((state) => state.signup);
+  const isMinInterestsSelected = signupState.interests.length >= 2;
+  const allInterests = [
+    "서버/백앤드 개발자",
+    "웹 풀스택 개발자",
+    "안드로이드 개발자",
+    "IOS 개발자",
+    "크로스플랫폼 앱개발자",
+    "게임 클라이언트 개발자",
+    "DBA",
+    "빅데이터 엔지니어",
+    "인공지능/머신러닝",
+    "프론트엔드 개발자",
+    "개발 PM",
+    "게임 서버 개발자",
+    "블록체인",
+    "QA엔지니어",
+    "웹퍼블리셔",
+  ];
+  const allInterestsCheckboxHandler = (e: any) => {
+    if (e.target.checked) {
+      dispatch(
+        setSignupData({
+          interests: allInterests,
+        }),
+      );
+    } else {
+      dispatch(
+        setSignupData({
+          interests: [],
+        }),
+      );
+    }
+  };
+
+  const interestCheckboxHandler = (selectedInterest: string) => {
+    const isExist = signupState.interests.includes(selectedInterest);
+    if (!isExist) {
+      dispatch(
+        setSignupData({
+          interests: [...signupState.interests, selectedInterest],
+        }),
+      );
+    } else {
+      dispatch(
+        setSignupData({
+          interests: [
+            ...signupState.interests.filter(
+              (interest: string) => interest !== selectedInterest,
+            ),
+          ],
+        }),
+      );
+    }
+  };
+
+  const proposalCheckboxHandler = (proposal: string) => {
+    dispatch(
+      setSignupData({
+        [proposal]: !signupState[proposal],
+      }),
+    );
+  };
+
+  const submitHandler = (e: any) => {
+    console.log(signupState);
+    e.preventDefault();
+    dispatch(
+      setSignupData({
+        interests: signupState.interests,
+        projectProposal: signupState.projectProposal,
+        feedbackProposal: signupState.feedbackProposal,
+        jobProposal: signupState.jobProposal,
+      }),
+    );
+    setStep(4);
+  };
+  return (
+    <form onSubmit={submitHandler}>
+      <div>
+        <input
+          type="checkbox"
+          onChange={(e) => allInterestsCheckboxHandler(e)}
+        />
+        <label>전체</label>
+
+        {allInterests.map((interest) => (
+          <div key={interest}>
+            <input
+              type="checkbox"
+              checked={signupState.interests.includes(interest)}
+              onChange={() => interestCheckboxHandler(interest)}
+            />
+            <label>{interest}</label>
+          </div>
+        ))}
+
+        <div>관심 분야</div>
+        <div>최소 2개 이상</div>
+      </div>
+
+      <div>
+        <div>제안 허용</div>
+
+        <label>채용 제안</label>
+        <input
+          type="checkbox"
+          onChange={() => proposalCheckboxHandler("jobProposal")}
+          checked={signupState.jobProposal}
+        />
+
+        <label>의견 제안</label>
+        <input
+          type="checkbox"
+          onChange={() => proposalCheckboxHandler("feedbackProposal")}
+          checked={signupState.feedbackProposal}
+        />
+
+        <label>프로젝트 제안</label>
+        <input
+          type="checkbox"
+          onChange={() => proposalCheckboxHandler("projectProposal")}
+          checked={signupState.projectProposal}
+        />
+      </div>
+      <button disabled={!isMinInterestsSelected} type="submit">
+        완료
+      </button>
+    </form>
+  );
+};
+
+export default InterestAndPrivacyForm;

--- a/apps/web/components/signup/SignUpSuccess.tsx
+++ b/apps/web/components/signup/SignUpSuccess.tsx
@@ -1,0 +1,20 @@
+import { useRouter } from "next/navigation";
+import { useAppSelector } from "../../hooks/redux";
+
+const SignUpSuccess = () => {
+  const signupData = useAppSelector((state) => state.signup);
+
+  const router = useRouter();
+  const ClickHandler = () => {
+    console.log(signupData);
+    router.replace("/login");
+  };
+  return (
+    <div>
+      스팩로그와 함께하세요
+      <button onClick={ClickHandler}>메인로그 바로가기</button>
+    </div>
+  );
+};
+
+export default SignUpSuccess;

--- a/apps/web/components/signup/SignupForm.tsx
+++ b/apps/web/components/signup/SignupForm.tsx
@@ -1,0 +1,259 @@
+import type { Dispatch, SetStateAction } from "react";
+import {
+  authenticateAdminWithPassword,
+  createUser,
+  getUsersByFields,
+  requestVerification,
+  usernameDoubleCheck,
+} from "../../apis/auth";
+import { useAppDispatch, useAppSelector } from "../../hooks/redux";
+import { setSignupData } from "../../store/signupSlice";
+import type { ListResponse } from "../../types/response";
+import type { User } from "../../types/user";
+
+interface SignupFormProps {
+  setStep: Dispatch<SetStateAction<number>>;
+}
+
+const SignupForm = ({ setStep }: SignupFormProps) => {
+  const dispatch = useAppDispatch();
+  const signupState = useAppSelector((state) => state.signup);
+  const allChecked =
+    signupState.collectionAndUse &&
+    signupState.identification &&
+    signupState.telCompany &&
+    signupState.termsOfService;
+
+  const handleCheckboxChange = (fieldName: string) => {
+    dispatch(setSignupData({ [fieldName]: !signupState[fieldName] }));
+  };
+
+  const handleAllCheckChange = () => {
+    dispatch(
+      setSignupData({
+        collectionAndUse: !allChecked,
+        identification: !allChecked,
+        telCompany: !allChecked,
+        termsOfService: !allChecked,
+        marketing: !allChecked,
+      }),
+    );
+  };
+
+  const handleDoubleCheck = async () => {
+    const username = "jwjeon";
+    const response = await usernameDoubleCheck(username);
+
+    if (response && "items" in response && response.items.length !== 0) {
+      dispatch(setSignupData({ usernameVerification: "Unverified" }));
+      alert("사용중인 닉네임입니다.");
+    } else {
+      dispatch(setSignupData({ usernameVerification: "Verified" }));
+      alert("사용가능한 닉네임입니다.");
+    }
+  };
+
+  const handleEmailAuthentication = async () => {
+    const email = "aaawodhks@nate.com";
+    const password = "password!";
+    const passwordConfirm = "password!";
+    const emailVisibility = true;
+
+    const response = await getUsersByFields("email", email);
+
+    if (response && "items" in response && response.items.length !== 0) {
+      emailVerificationCheck(response, email);
+    } else {
+      createUserAndEmailVerification({
+        email,
+        password,
+        passwordConfirm,
+        emailVisibility,
+      });
+    }
+  };
+
+  const emailVerificationCheck = async (
+    response: ListResponse<User>,
+    email: string,
+  ) => {
+    const user = response.items[0];
+    if (user?.verified) {
+      dispatch(setSignupData({ emailVerification: "Verified" }));
+      alert("인증이 완료된 이메일 입니다.");
+    } else {
+      const emailResponse = await requestVerification(email);
+
+      if (emailResponse === null) {
+        dispatch(setSignupData({ emailVerification: "InProgress" }));
+        alert("인증 메일을 발송하였습니다.");
+      }
+    }
+  };
+
+  const createUserAndEmailVerification = async ({
+    email,
+    password,
+    passwordConfirm,
+    emailVisibility,
+  }: User) => {
+    const adminToken = await getAdminToken();
+
+    await createUser(
+      {
+        email,
+        password,
+        passwordConfirm,
+        emailVisibility,
+      },
+      adminToken,
+    );
+
+    const emailResponse = await requestVerification(email);
+
+    if (emailResponse === null) {
+      dispatch(setSignupData({ emailVerification: "InProgress" }));
+      alert("인증 메일을 발송하였습니다.");
+    }
+  };
+
+  const getAdminToken = async () => {
+    const response = await authenticateAdminWithPassword();
+    return response && "token" in response ? response.token : "";
+  };
+
+  const submitHandler = (e: any) => {
+    e.preventDefault();
+    dispatch(
+      setSignupData({
+        name: "testname",
+        username: "testUsername",
+        email: "testemail@test.com",
+        password: "testpassword!",
+        passwordConfirm: "testpassword!",
+        collectionAndUse: signupState.collectionAndUse,
+        identification: signupState.identification,
+        telCompany: signupState.telCompany,
+        termsOfService: signupState.termsOfService,
+        marketing: signupState.marketing,
+      }),
+    );
+    setStep(3);
+  };
+  return (
+    <form onSubmit={submitHandler}>
+      <div>
+        <label>이름</label>
+        <input type="text" className="border border-gray-400" />
+      </div>
+      <div>
+        <label>닉네임</label>
+        <input type="text" className="border border-gray-400" />
+        <button
+          disabled={signupState.usernameVerification === "Verified"}
+          onClick={handleDoubleCheck}
+          type="button"
+        >
+          {signupState.usernameVerification === "Unverified"
+            ? "중복 확인"
+            : "사용 가능"}
+        </button>
+      </div>
+
+      <div>
+        <label>이메일</label>
+        <input type="text" className="border border-gray-400" />
+        <button
+          disabled={signupState.emailVerification === "Verified"}
+          onClick={handleEmailAuthentication}
+          type="button"
+        >
+          {signupState.emailVerification === "Unverified"
+            ? "인증요청"
+            : "인증확인"}
+        </button>
+      </div>
+
+      <div>
+        <label>비밀번호</label>
+        <input type="password" className="border border-gray-400" />
+      </div>
+
+      <div>
+        <label>비밀번호 확인</label>
+        <input type="password" className="border border-gray-400" />
+      </div>
+
+      <div>
+        <label>본인인증 약관 전체동의 (필수)</label>
+        <input
+          type="checkbox"
+          checked={allChecked}
+          onChange={handleAllCheckChange}
+        />
+
+        <label>개인정보 수집 이용 동의 (필수)</label>
+        <input
+          required
+          type="checkbox"
+          checked={signupState.collectionAndUse}
+          onChange={() => handleCheckboxChange("collectionAndUse")}
+        />
+
+        <label>고유식별 정보처리 동의 (필수)</label>
+        <input
+          required
+          type="checkbox"
+          checked={signupState.identification}
+          onChange={() => handleCheckboxChange("identification")}
+        />
+
+        <label>통신사 이용약관 동의 (필수)</label>
+        <input
+          required
+          type="checkbox"
+          checked={signupState.telCompany}
+          onChange={() => handleCheckboxChange("telCompany")}
+        />
+
+        <label>서비스 이용약관 동의 (필수)</label>
+        <input
+          required
+          type="checkbox"
+          checked={signupState.termsOfService}
+          onChange={() => handleCheckboxChange("termsOfService")}
+        />
+
+        <label>마케팅 정보 수신 동의 (선택)</label>
+        <input
+          type="checkbox"
+          checked={signupState.marketing}
+          onChange={() => handleCheckboxChange("marketing")}
+        />
+      </div>
+
+      <div>
+        <button
+          disabled={!allChecked}
+          type="submit"
+          style={{
+            display: "flex",
+            width: "670px",
+            height: "80px",
+            padding: "25px 314px",
+            justifyContent: "center",
+            alignItems: "center",
+            gap: "10px",
+            flexShrink: 0,
+            borderRadius: "15px",
+            background: "var(--neutral-30, #B3B3B3)",
+          }}
+        >
+          다음
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default SignupForm;

--- a/apps/web/components/signup/SignupTerm.tsx
+++ b/apps/web/components/signup/SignupTerm.tsx
@@ -1,0 +1,213 @@
+import type { Dispatch, SetStateAction } from "react";
+import { useAppDispatch, useAppSelector } from "../../hooks/redux";
+import { setSignupData } from "../../store/signupSlice";
+
+interface SignupTermProps {
+  setStep: Dispatch<SetStateAction<number>>;
+}
+const SignupTerm = ({ setStep }: SignupTermProps) => {
+  const dispatch = useAppDispatch();
+  const signupState = useAppSelector((state) => state.signup);
+  const allChecked = signupState.privacyPolicy && signupState.termsOfService;
+
+  const handleAllCheckChange = () => {
+    dispatch(
+      setSignupData({
+        privacyPolicy: !allChecked,
+        termsOfService: !allChecked,
+      }),
+    );
+  };
+
+  const handleAgreeCheckboxChange = (fieldName: string) => {
+    dispatch(setSignupData({ [fieldName]: true }));
+  };
+
+  const handleDisagreeCheckboxChange = (fieldName: string) => {
+    dispatch(setSignupData({ [fieldName]: false }));
+  };
+
+  const submitHandler = (e: any) => {
+    e.preventDefault();
+    dispatch(
+      setSignupData({
+        privacyPolicy: signupState.privacyPolicy,
+        termsOfService: !signupState.termsOfService,
+      }),
+    );
+    setStep(2);
+  };
+
+  return (
+    <form onSubmit={submitHandler}>
+      <div style={{ display: "flex" }}>
+        <div>개인정보처리방침</div>
+        <div>
+          <label>전체 동의</label>
+          <input
+            onChange={handleAllCheckChange}
+            type="checkbox"
+            checked={allChecked}
+          />
+        </div>
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          width: "675px",
+          height: "410px",
+          flexDirection: "column",
+          alignItems: "flex-start",
+          gap: "10px",
+          flexShrink: 0,
+          border: "1px solid black",
+          fontSize: "12px",
+          fontStyle: "normal",
+          fontWeight: 400,
+          lineHeight: "16px",
+          overflow: "scroll",
+        }}
+      >
+        국가는 농수산물의 수급균형과 유통구조의 개선에 노력하여 가격안정을
+        도모함으로써 농·어민의 이익을 보호한다. 국가는 사회보장·사회복지의
+        증진에 노력할 의무를 진다. 국회의원의 수는 법률로 정하되, 200인 이상으로
+        한다. 대통령의 임기연장 또는 중임변경을 위한 헌법개정은 그 헌법개정 제안
+        당시의 대통령에 대하여는 효력이 없다. 제3항의 승인을 얻지 못한 때에는 그
+        처분 또는 명령은 그때부터 효력을 상실한다. 이 경우 그 명령에 의하여 개정
+        또는 폐지되었던 법률은 그 명령이 승인을 얻지 못한 때부터 당연히 효력을
+        회복한다. 국회는 헌법 또는 법률에 특별한 규정이 없는 한 재적의원
+        과반수의 출석과 출석의원 과반수의 찬성으로 의결한다. 가부동수인 때에는
+        부결된 것으로 본다. 법률이 헌법에 위반되는 여부가 재판의 전제가 된
+        경우에는 법원은 헌법재판소에 제청하여 그 심판에 의하여 재판한다. 모든
+        국민은 직업선택의 자유를 가진다. 교육의 자주성·전문성·정치적 중립성 및
+        대학의 자율성은 법률이 정하는 바에 의하여 보장된다. 정부는 회계연도마다
+        예산안을 편성하여 회계연도 개시 90일전까지 국회에 제출하고, 국회는
+        회계연도 개시 30일전까지 이를 의결하여야 한다. 헌법재판소는 법률에
+        저촉되지 아니하는 범위안에서 심판에 관한 절차, 내부규율과 사무처리에
+        관한 규칙을 제정할 수 있다. 이 헌법공포 당시의 국회의원의 임기는 제1항에
+        의한 국회의 최초의 집회일 전일까지로 한다. 대법원은 법률에 저촉되지
+        아니하는 범위안에서 소송에 관한 절차, 법원의 내부규율과 사무처리에 관한
+        규칙을 제정할 수 있다. 국가는 노인과 청소년의 복지향상을 위한 정책을
+        실시할 의무를 진다. 정당은 그 목적·조직과 활동이 민주적이어야 하며,
+        국민의 정치적 의사형성에 참여하는데 필요한 조직을 가져야 한다. 감사원의
+        조직·직무범위·감사위원의 자격·감사대상공무원의 범위 기타 필요한 사항은
+        법률로 정한다. 국가는 건전한 소비행위를 계도하고 생산품의 품질향상을
+        촉구하기 위한 소비자보호운동을 법률이 정하는 바에 의하여 보장한다.
+        국회에 제출된 법률안 기타의 의안은 회기중에 의결되지 못한 이유로
+        폐기되지 아니한다. 다만, 국회의원의 임기가 만료된 때에는 그러하지
+        아니하다.
+      </div>
+
+      <div style={{ display: "flex" }}>
+        <div>
+          <label>동의</label>
+          <input
+            required
+            onChange={() => handleAgreeCheckboxChange("privacyPolicy")}
+            type="checkbox"
+            checked={signupState.privacyPolicy}
+          />
+        </div>
+
+        <div>
+          <label>거부</label>
+          <input
+            onChange={() => handleDisagreeCheckboxChange("privacyPolicy")}
+            type="checkbox"
+            checked={!signupState.privacyPolicy}
+          />
+        </div>
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          width: "675px",
+          height: "410px",
+          flexDirection: "column",
+          alignItems: "flex-start",
+          gap: "10px",
+          flexShrink: 0,
+          border: "1px solid black",
+          fontSize: "12px",
+          fontStyle: "normal",
+          fontWeight: 400,
+          lineHeight: "16px",
+          overflow: "scroll",
+        }}
+      >
+        국가는 농수산물의 수급균형과 유통구조의 개선에 노력하여 가격안정을
+        도모함으로써 농·어민의 이익을 보호한다. 국가는 사회보장·사회복지의
+        증진에 노력할 의무를 진다. 국회의원의 수는 법률로 정하되, 200인 이상으로
+        한다. 대통령의 임기연장 또는 중임변경을 위한 헌법개정은 그 헌법개정 제안
+        당시의 대통령에 대하여는 효력이 없다. 제3항의 승인을 얻지 못한 때에는 그
+        처분 또는 명령은 그때부터 효력을 상실한다. 이 경우 그 명령에 의하여 개정
+        또는 폐지되었던 법률은 그 명령이 승인을 얻지 못한 때부터 당연히 효력을
+        회복한다. 국회는 헌법 또는 법률에 특별한 규정이 없는 한 재적의원
+        과반수의 출석과 출석의원 과반수의 찬성으로 의결한다. 가부동수인 때에는
+        부결된 것으로 본다. 법률이 헌법에 위반되는 여부가 재판의 전제가 된
+        경우에는 법원은 헌법재판소에 제청하여 그 심판에 의하여 재판한다. 모든
+        국민은 직업선택의 자유를 가진다. 교육의 자주성·전문성·정치적 중립성 및
+        대학의 자율성은 법률이 정하는 바에 의하여 보장된다. 정부는 회계연도마다
+        예산안을 편성하여 회계연도 개시 90일전까지 국회에 제출하고, 국회는
+        회계연도 개시 30일전까지 이를 의결하여야 한다. 헌법재판소는 법률에
+        저촉되지 아니하는 범위안에서 심판에 관한 절차, 내부규율과 사무처리에
+        관한 규칙을 제정할 수 있다. 이 헌법공포 당시의 국회의원의 임기는 제1항에
+        의한 국회의 최초의 집회일 전일까지로 한다. 대법원은 법률에 저촉되지
+        아니하는 범위안에서 소송에 관한 절차, 법원의 내부규율과 사무처리에 관한
+        규칙을 제정할 수 있다. 국가는 노인과 청소년의 복지향상을 위한 정책을
+        실시할 의무를 진다. 정당은 그 목적·조직과 활동이 민주적이어야 하며,
+        국민의 정치적 의사형성에 참여하는데 필요한 조직을 가져야 한다. 감사원의
+        조직·직무범위·감사위원의 자격·감사대상공무원의 범위 기타 필요한 사항은
+        법률로 정한다. 국가는 건전한 소비행위를 계도하고 생산품의 품질향상을
+        촉구하기 위한 소비자보호운동을 법률이 정하는 바에 의하여 보장한다.
+        국회에 제출된 법률안 기타의 의안은 회기중에 의결되지 못한 이유로
+        폐기되지 아니한다. 다만, 국회의원의 임기가 만료된 때에는 그러하지
+        아니하다.
+      </div>
+
+      <div style={{ display: "flex" }}>
+        <div>
+          <label>동의</label>
+          <input
+            required
+            onChange={() => handleAgreeCheckboxChange("termsOfService")}
+            type="checkbox"
+            checked={signupState.termsOfService}
+          />
+        </div>
+
+        <div>
+          <label>거부</label>
+          <input
+            onChange={() => handleDisagreeCheckboxChange("termsOfService")}
+            type="checkbox"
+            checked={!signupState.termsOfService}
+          />
+        </div>
+      </div>
+
+      <button
+        disabled={!signupState.privacyPolicy || !signupState.termsOfService}
+        type="submit"
+        style={{
+          display: "flex",
+          width: "670px",
+          height: "80px",
+          padding: "25px 314px",
+          justifyContent: "center",
+          alignItems: "center",
+          gap: "10px",
+          flexShrink: 0,
+          borderRadius: "15px",
+          background: "var(--neutral-30, #B3B3B3)",
+        }}
+      >
+        다음
+      </button>
+    </form>
+  );
+};
+
+export default SignupTerm;

--- a/apps/web/store/loginSlice.ts
+++ b/apps/web/store/loginSlice.ts
@@ -1,0 +1,35 @@
+import { PayloadAction, createSlice } from "@reduxjs/toolkit";
+
+interface LoginData {
+  email: string;
+  password: string;
+  token: string;
+  rememberUser: boolean;
+  isLoggedIn: boolean;
+}
+
+const loginInitialState: LoginData = {
+  email: "",
+  password: "",
+  token: "",
+  rememberUser: false,
+  isLoggedIn: false,
+};
+
+const loginSlice = createSlice({
+  name: "login",
+  initialState: loginInitialState,
+  reducers: {
+    setLoginData: (state, action: PayloadAction<Partial<LoginData>>) => {
+      Object.assign(state, action.payload);
+    },
+    login: (state, action: PayloadAction<LoginData>) => {
+      state = { ...state, ...action.payload, isLoggedIn: true };
+    },
+    logout: () => loginInitialState,
+  },
+});
+
+export const { setLoginData, login, logout } = loginSlice.actions;
+export const selectLogin = (state: { login: LoginData }) => state.login;
+export default loginSlice.reducer;

--- a/apps/web/store/signupSlice.ts
+++ b/apps/web/store/signupSlice.ts
@@ -1,0 +1,58 @@
+import { PayloadAction, createSlice } from "@reduxjs/toolkit";
+
+interface SignupData {
+  name: string;
+  username: string;
+  email: string;
+  password: string;
+  passwordConfirm: string;
+  privacyPolicy: boolean;
+  termsOfService: boolean;
+  collectionAndUse: boolean;
+  identification: boolean;
+  telCompany: boolean;
+  marketing: boolean;
+  jobProposal: boolean;
+  feedbackProposal: boolean;
+  projectProposal: boolean;
+  interests: string[];
+  usernameVerification: "Unverified" | "InProgress" | "Verified";
+  emailVerification: "Unverified" | "InProgress" | "Verified";
+}
+
+const signupInitialState: SignupData = {
+  name: "",
+  username: "",
+  email: "",
+  password: "",
+  passwordConfirm: "",
+  privacyPolicy: false,
+  termsOfService: false,
+  collectionAndUse: false,
+  identification: false,
+  telCompany: false,
+  marketing: false,
+  jobProposal: false,
+  feedbackProposal: false,
+  projectProposal: false,
+  interests: [],
+  usernameVerification: "Unverified",
+  emailVerification: "Unverified",
+};
+
+const signupSlice = createSlice({
+  name: "signup",
+  initialState: signupInitialState,
+  reducers: {
+    setSignupData: (state, action: PayloadAction<Partial<SignupData>>) => {
+      Object.assign(state, action.payload);
+    },
+    reset: (state) => {
+      Object.assign(state, signupInitialState);
+    },
+  },
+});
+
+export const { setSignupData, reset } = signupSlice.actions;
+export const selectSignup = (state: { signup: SignupData }) => state.signup;
+export default signupSlice.reducer;

--- a/apps/web/store/store.ts
+++ b/apps/web/store/store.ts
@@ -2,9 +2,11 @@
 
 import { configureStore } from "@reduxjs/toolkit";
 import counterSlice from "./counterSlice";
+import loginSlice from "./loginSlice";
+import signupSlice from "./signupSlice";
 
 const store: any = configureStore({
-  reducer: { counter: counterSlice },
+  reducer: { counter: counterSlice, signup: signupSlice, login: loginSlice },
 });
 
 export type RootState = ReturnType<typeof store.getState>;

--- a/apps/web/types/auth.ts
+++ b/apps/web/types/auth.ts
@@ -1,0 +1,20 @@
+import type { User } from "./user";
+
+export interface LoginFormData {
+  identity: string;
+  password: string;
+}
+
+export interface LoginResponse {
+  record: User;
+  token: string;
+}
+
+export interface signupFormData {
+  name?: string;
+  username?: string;
+  email: string;
+  password: string;
+  passwordConfirm: string;
+  emailVisibility?: boolean;
+}

--- a/apps/web/types/log.ts
+++ b/apps/web/types/log.ts
@@ -3,11 +3,3 @@ export interface Log {
   id: string;
   title: string;
 }
-
-export interface LogsResponse {
-  page: number;
-  perPage: number;
-  totalPages: number;
-  totalItems: number;
-  items: Log[];
-}

--- a/apps/web/types/response.ts
+++ b/apps/web/types/response.ts
@@ -1,0 +1,15 @@
+export interface ErrorResponse {
+  code: number;
+  message: string;
+  data: {
+    [key: string]: { code: string; message: string } | null;
+  };
+}
+
+export interface ListResponse<T> {
+  page: number;
+  perPage: number;
+  totalPages: number;
+  totalItems: number;
+  items: T[];
+}

--- a/apps/web/types/user.ts
+++ b/apps/web/types/user.ts
@@ -1,0 +1,10 @@
+export interface User {
+  id?: string;
+  email: string;
+  name?: string;
+  username?: string;
+  password: string;
+  passwordConfirm: string;
+  emailVisibility?: boolean;
+  verified?: boolean;
+}

--- a/apps/web/utils/fetcher.ts
+++ b/apps/web/utils/fetcher.ts
@@ -1,3 +1,4 @@
+import type { ErrorResponse } from "../types/response";
 interface FetcherOptions {
   method?: string;
   headers?: Record<string, string>;
@@ -7,7 +8,7 @@ interface FetcherOptions {
 const fetcher = async <T>(
   url: string,
   options: FetcherOptions = {},
-): Promise<T | null> => {
+): Promise<T | ErrorResponse | null> => {
   const response = await fetch(url, {
     method: options.method || "GET",
     headers: options.headers || {},

--- a/apps/web/utils/withAuth.tsx
+++ b/apps/web/utils/withAuth.tsx
@@ -1,0 +1,36 @@
+"use client";
+import { redirect } from "next/navigation";
+import { useEffect } from "react";
+import { useAppDispatch } from "../hooks/redux";
+import { setLoginData } from "../store/loginSlice";
+
+const withAuth = (Component: any) => {
+  return (props: any) => {
+    const dispatch = useAppDispatch();
+
+    useEffect(() => {
+      const storedToken =
+        typeof window !== "undefined" ? sessionStorage.getItem("token") : null;
+      const expirationTime =
+        typeof window !== "undefined"
+          ? sessionStorage.getItem("tokenExpiration")
+          : null;
+      if (storedToken && expirationTime) {
+        const currentTime = new Date().getTime();
+        const expirationTimeInMillis = parseInt(expirationTime, 10);
+
+        if (currentTime > expirationTimeInMillis) {
+          sessionStorage.removeItem("token");
+          sessionStorage.removeItem("tokenExpiration");
+        } else {
+          dispatch(setLoginData({ isLoggedIn: true }));
+          return redirect("/");
+        }
+      }
+    }, []);
+
+    return <Component {...props} />;
+  };
+};
+
+export default withAuth;

--- a/apps/web/utils/withGuest.tsx
+++ b/apps/web/utils/withGuest.tsx
@@ -1,0 +1,19 @@
+"use client";
+import { redirect } from "next/navigation";
+import { useEffect } from "react";
+
+const withGuest = (Component: any) => {
+  return (props: any) => {
+    useEffect(() => {
+      const storedToken =
+        typeof window !== "undefined" ? sessionStorage.getItem("token") : null;
+      if (!storedToken) {
+        return redirect("/login");
+      }
+    }, []);
+
+    return <Component {...props} />;
+  };
+};
+
+export default withGuest;

--- a/turbo.json
+++ b/turbo.json
@@ -8,7 +8,12 @@
     },
     "lint": {
       "dependsOn": ["^lint"],
-      "env": ["NEXT_PUBLIC_API_URL"]
+      "env": [
+        "NEXT_PUBLIC_API_URL",
+        "NEXT_PUBLIC_ADMIN_API_URL",
+        "NEXT_PUBLIC_ADMIN_EMAIL",
+        "NEXT_PUBLIC_ADMIN_PASSWORD"
+      ]
     },
     "dev": {
       "cache": false,


### PR DESCRIPTION

## 작업사항
 - api 관련 타입 정의
 - 인증 관련 HOC 구현
 - Auth with password api 연동
 - Create users api 연동
 - Request verification api 연동
 - Request password reset api 연동
 - Delete users api 연동

## 미리보기 및 사용방법
![image](https://github.com/33-ohoh/33-ohoh/assets/65522153/120a55df-5fa4-4301-8bc7-b1784ca529e6)


## 기타

- react-hook-form 적용 하면서 수정이 필요하기때문에 핵심 기능이 동작하는 것에 맞춰 개발, ui 컴포넌트 구현과 함께 수정 예정
- admin api를 사용하기 위해서 아래의 환경 변수 추가

`NEXT_PUBLIC_ADMIN_API_URL`=ip주소/api/admins
`NEXT_PUBLIC_ADMIN_EMAIL`=포켓베이스 로그인 이메일
`NEXT_PUBLIC_ADMIN_PASSWORD`=포켓베이스 로그인 비밀번호

## 작성일

2024.01.29
