### PR TITLE
[Feat] 게시물 DB저장 및 저장 성공시 로직 구현 #70

### DIFF
--- a/apps/web/app/log-success/[id]/page.tsx
+++ b/apps/web/app/log-success/[id]/page.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import PocketBase from "pocketbase";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import Image from "next/image";
+
+const pb = new PocketBase("http://13.209.16.46:8090");
+
+type LogParams = {
+  id: string;
+};
+
+interface LogResponse {
+  collectionId: string;
+  collectionName: string;
+  commentCount: number;
+  content: string;
+  created: string;
+  hitCount: number;
+  id: string;
+  isPublic: boolean;
+  isQuestion: boolean;
+  isTemporary: boolean;
+  likeCount: number;
+  series: string;
+  tags: string[];
+  thumbnail: string;
+  title: string;
+  updated: string;
+  user: string;
+}
+
+const LogSuccess = ({ params }: { params: LogParams }) => {
+  const [log, setLog] = useState<LogResponse | null>(null);
+
+  const logId = params.id;
+
+  const router = useRouter();
+
+  useEffect(() => {
+    const fetchLog = async () => {
+      if (!logId) return;
+
+      try {
+        const record: LogResponse = await pb.collection("logs").getOne(logId, {
+          expand: "relField1,relField2.subRelField",
+        });
+        setLog(record);
+        console.log(record);
+      } catch (error) {
+        console.error(error);
+      }
+    };
+
+    fetchLog();
+  }, [logId]);
+
+  const handleConfirmClick = () => {
+    if (log?.id) {
+      router.push(`/log/${log.id}`);
+    }
+  };
+
+  const defaultThumbnail = "/recommendedThumbnail.png";
+
+  const logThumbnail = `http://13.209.16.46:8090/api/files/fa9narwwpt53ps8/${log?.id}/${log?.thumbnail}`;
+
+  return (
+    <div className="w-[470px] mx-auto flex flex-col items-center mt-mediun mb-extraLarge">
+      {log?.thumbnail ? (
+        <Image
+          src={logThumbnail}
+          alt="Log Thumbnail"
+          width={300}
+          height={300}
+        />
+      ) : (
+        <Image
+          src={defaultThumbnail}
+          alt="Default Thumbnail"
+          width={300}
+          height={300}
+        />
+      )}
+      <h2 className="display4 mt-extraSmall1">
+        {log?.isQuestion ? "[질문]" : "[로그]"}
+        {log?.title}
+      </h2>
+      <div className="flex flex-col items-center mt-extraSmall5">
+        <span className="body3R">로그를 업로드하였습니다.</span>
+        <span className="body3R">지금 바로 다양한 작업을 감상해보세요!</span>
+      </div>
+      <button
+        onClick={handleConfirmClick}
+        className="bg-primary90 w-full h-[60px] rounded-radius15 text-white headline1 mt-small1"
+      >
+        확인
+      </button>
+    </div>
+  );
+};
+
+export default LogSuccess;

--- a/apps/web/app/log/[id]/page.tsx
+++ b/apps/web/app/log/[id]/page.tsx
@@ -106,8 +106,6 @@ const LogPage = ({ params }: { params: LogParams }) => {
     ? `http://13.209.16.46:8090/api/files/_pb_users_auth_/${userProfile.id}/${userProfile.avatar}`
     : null;
 
-  console.log(log);
-
   return (
     <div className="mt-regular1 mb-extraLarge">
       <section className="w-[1180px] mx-auto">

--- a/apps/web/app/log/page.tsx
+++ b/apps/web/app/log/page.tsx
@@ -3,10 +3,11 @@
 import { NavDown } from "@repo/ui/index";
 import QuillEditor from "@repo/ui/quillEditor";
 import Image from "next/image";
-import { useEffect, useState, ChangeEvent } from "react";
+import { useRouter } from "next/navigation";
+import PocketBase from "pocketbase";
+import { ChangeEvent, useEffect, useState } from "react";
 import DraftModal from "../../components/log/DraftModal";
 import TemplateModal from "../../components/log/templateModal";
-import PocketBase from "pocketbase";
 
 const pb = new PocketBase("http://13.209.16.46:8090");
 
@@ -19,6 +20,8 @@ const Page = () => {
   const [publishTime, setPublishTime] = useState("now");
   const [title, setTitle] = useState<string>("");
   const [content, setContent] = useState<string>("");
+
+  const router = useRouter();
 
   // 제목과 내용 입력 핸들러
   const handleTitleChange = (e: ChangeEvent<HTMLInputElement>) => {
@@ -33,7 +36,7 @@ const Page = () => {
   // 게시물 등록 함수
   const handleSubmit = async () => {
     try {
-      const newRecord = await pb.collection("logs").create({
+      const logData = {
         collectionName: "logs",
         created: publishTime,
         title,
@@ -48,10 +51,13 @@ const Page = () => {
         tags: selectedTags,
         user: "y78rq48jvf5muh9",
         series: "2o39vccfkf1jcyj",
-      });
+      };
+
+      const newRecord = await pb.collection("logs").create(logData);
 
       // 게시물 등록 성공 후 처리, 예: 사용자에게 성공 메시지 표시, 페이지 리디렉션 등
       console.log("Post created successfully:", newRecord);
+      router.push(`/log-success/${newRecord.id}`);
     } catch (error) {
       // 게시물 등록 실패 처리, 예: 사용자에게 오류 메시지 표시
       console.error("Error creating post:", error);

--- a/apps/web/app/log/page.tsx
+++ b/apps/web/app/log/page.tsx
@@ -3,18 +3,60 @@
 import { NavDown } from "@repo/ui/index";
 import QuillEditor from "@repo/ui/quillEditor";
 import Image from "next/image";
-import { useEffect, useState } from "react";
+import { useEffect, useState, ChangeEvent } from "react";
 import DraftModal from "../../components/log/DraftModal";
 import TemplateModal from "../../components/log/templateModal";
+import PocketBase from "pocketbase";
+
+const pb = new PocketBase("http://13.209.16.46:8090");
 
 const Page = () => {
   const [isTemplateModalOpen, setTemplateModalOpen] = useState(false);
   const [isDraftModalOpen, setDraftModalOpen] = useState(false);
   const [showAllTags, setShowAllTags] = useState<boolean>(false);
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
-  //   const [images, setImages] = useState([]);
   const [thumbnail, setThumbnail] = useState("");
-  const [publishTime, setPublishTime] = useState("now"); // 'now' 또는 'schedule'
+  const [publishTime, setPublishTime] = useState("now");
+  const [title, setTitle] = useState<string>("");
+  const [content, setContent] = useState<string>("");
+
+  // 제목과 내용 입력 핸들러
+  const handleTitleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setTitle(e.target.value);
+  };
+
+  // QuillEditor에서 사용될 내용 변경 핸들러
+  const handleContentChange = (newContent: string) => {
+    setContent(newContent);
+  };
+
+  // 게시물 등록 함수
+  const handleSubmit = async () => {
+    try {
+      const newRecord = await pb.collection("logs").create({
+        collectionName: "logs",
+        created: publishTime,
+        title,
+        content,
+        thumbnail,
+        isPublic: true,
+        isQuestion: false,
+        isBookmark: false,
+        hitCount: 722,
+        likeCount: 722,
+        commentCount: 722,
+        tags: selectedTags,
+        user: "y78rq48jvf5muh9",
+        series: "2o39vccfkf1jcyj",
+      });
+
+      // 게시물 등록 성공 후 처리, 예: 사용자에게 성공 메시지 표시, 페이지 리디렉션 등
+      console.log("Post created successfully:", newRecord);
+    } catch (error) {
+      // 게시물 등록 실패 처리, 예: 사용자에게 오류 메시지 표시
+      console.error("Error creating post:", error);
+    }
+  };
 
   // 템플릿 모달 토글
   const toggleTemplateModal = () => {
@@ -124,8 +166,10 @@ const Page = () => {
           id="title"
           placeholder="제목"
           className="w-full border-b mb-extraSmall1 display2 focus:outline-none p-[10px]"
+          value={title}
+          onChange={handleTitleChange}
         />
-        <QuillEditor />
+        <QuillEditor value={content} onChange={handleContentChange} />
       </div>
       <div className="flex flex-col gap-[15px] mt-small1">
         <div>
@@ -622,7 +666,10 @@ const Page = () => {
         <button className="w-[210px] h-[46px] border-2 border-primary90 rounded-radius5 text-primary90 subhead1">
           취소
         </button>
-        <button className="w-[210px] h-[46px] bg-primary90 text-white rounded-radius5 subhead1">
+        <button
+          className="w-[210px] h-[46px] bg-primary90 text-white rounded-radius5 subhead1"
+          onClick={handleSubmit}
+        >
           등록
         </button>
       </div>

--- a/packages/ui/src/quillEditor.tsx
+++ b/packages/ui/src/quillEditor.tsx
@@ -5,51 +5,26 @@ import ReactQuill from "react-quill";
 import "react-quill/dist/quill.snow.css";
 import "./quillEditor.css";
 
-const QuillEditor = () => {
-  const [text, setText] = useState("");
-  const handleChange = (
-    content: string,
-    delta: any,
-    source: string,
-    editor: any,
-  ): void => {
-    setText(editor.getHTML()); // rich text
-  };
+interface QuillEditorProps {
+  value: string;
+  onChange: (newContent: string) => void;
+}
 
-  return (
-    <ReactQuill
-      value={text}
-      onChange={handleChange}
-      modules={QuillEditor.modules}
-      formats={QuillEditor.formats}
-      bounds={".app"}
-      placeholder="내용을 입력하세요."
-    />
-  );
-};
-
-QuillEditor.modules = {
+// Quill 편집기에 사용할 모듈을 정의합니다.
+const modules = {
   toolbar: [
-    [{ header: [1, 2, 3, 4, 5, 6, false] }],
+    [{ header: "1" }, { header: "2" }, { font: [] }],
     [{ size: [] }],
     ["bold", "italic", "underline", "strike", "blockquote"],
-    [
-      { list: "ordered" },
-      { list: "bullet" },
-      { indent: "-1" },
-      { indent: "+1" },
-    ],
-    ["link", "image", "video", "code-block"],
-    [{ align: [] }, { color: [] }, { background: [] }], // dropdown with defaults from theme
+    [{ list: "ordered" }, { list: "bullet" }],
+    ["link", "image", "video"],
     ["clean"],
+    ["code-block"],
   ],
-  clipboard: {
-    // Toggle to add extra line breaks when pasting HTML:
-    matchVisual: false,
-  },
 };
 
-QuillEditor.formats = [
+// Quill 편집기에서 지원하는 포맷을 정의합니다.
+const formats = [
   "header",
   "font",
   "size",
@@ -60,14 +35,35 @@ QuillEditor.formats = [
   "blockquote",
   "list",
   "bullet",
-  "indent",
   "link",
   "image",
   "video",
+  "clean",
   "code-block",
-  "align",
-  "color",
-  "background",
 ];
+
+const QuillEditor: React.FC<QuillEditorProps> = ({ value, onChange }) => {
+  const handleChange = (
+    content: string,
+    delta: any,
+    source: string,
+    editor: any,
+  ): void => {
+    if (source === "user") {
+      onChange(editor.getHTML());
+    }
+  };
+
+  return (
+    <ReactQuill
+      value={value}
+      onChange={handleChange}
+      modules={modules}
+      formats={formats}
+      bounds={".app"}
+      placeholder="내용을 입력하세요."
+    />
+  );
+};
 
 export default QuillEditor;

--- a/packages/ui/src/quillEditor.tsx
+++ b/packages/ui/src/quillEditor.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import ReactQuill from "react-quill";
 import "react-quill/dist/quill.snow.css";
 import "./quillEditor.css";


### PR DESCRIPTION
<!--
1. 제목은 50자 이내
2. 장황하게 설명하지 않고 간단하게 기술
3. 과거 시제 사용 X
4. 명사형 어미 사용

* 제목양식
[태그] 제목 #이슈번호
태그 첫 글자는 대문자로
예시) [Feat] 로그인 기능 구현 #32

* 제목 태그 종류
[Feat] 새로운 기능 추가
[Fix] 버그 수정
[Docs] 문서 수정
[Style] 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
[Design] CSS 등 사용자 UI 디자인 변경
[Refactor] 코드 리팩토링
[Test] 테스트 코드, 리팩토링 테스트 코드 추가
[Chore] 빌드 업무 수정, 패키지 매니저 수정


* 작성 후 이슈, 라벨, 마일스톤 등 연결하기
* Assignees : 작업자
-->

## 작업사항

<!-- 작업한 내용 작성 -->

- 게시물 작성 페이지에서 포켓베이스 DB 게시물 저장 기능 구현
- 게시물 작성 성공 후 로직 구현
  - 게시물 등록 성공 페이지 마크업, 스타일링
  - 게시물 등록 성공 페이지에서 '확인' 버튼 클릭 시 작성한 게시물 조회 페이지로 이동

## 미리보기 및 사용방법

<!-- 미리보기 파일 첨부와 함께 사용 방법 작성. 이미지, 동영상 등 작업 내용을 확인할 수 있는 파일 첨부 -->
![Feb-07-2024 17-00-30](https://github.com/33-ohoh/33-ohoh/assets/69342971/1cb0f778-d6a9-4e71-92b3-19a66528fc55)

## 기타

<!-- 필요한 경우 작성 -->
- 게시글 작성 페이지에서 공개범위, 발행설정, 발행시간 등의 정보는 아직 게시물과 같이 저장하게끔 구현되어 있지 않음.
- 게시글 작성 페이지에서 게시글 썸네일을 설정할 수 있게끔 기능 구현 추가적으로 필요.
## 작성일

<!-- 풀 리퀘스트 작성한 날짜 작성 yyyy.mm.dd -->

2024.02.07
