### PR TITLE
[Feat] 메인페이지, 마이페이지 게시물 관련 페이지들 연결 #89

### DIFF
--- a/apps/web/app/main/page.tsx
+++ b/apps/web/app/main/page.tsx
@@ -3,7 +3,7 @@ import LogSection from "../../components/main/LogSection";
 
 const MainPage = () => {
   return (
-    <div className="w-[1440px] flex flex-col items-center">
+    <div className="w-[1440px] flex flex-col items-center mx-auto">
       <HotLogCardList />
       <LogSection />
     </div>

--- a/apps/web/components/main/Footer.tsx
+++ b/apps/web/components/main/Footer.tsx
@@ -4,7 +4,7 @@ import React from "react";
 
 const Footer = () => {
   return (
-    <div className="w-[1440px] h-[270px] flex flex-col justify-center bg-neutral60 px-[120px] py-[54px] mt-[150px] text-white">
+    <div className="w-[1440px] h-[270px] flex flex-col justify-center bg-neutral60 px-[120px] py-[54px] mt-[150px] text-white mx-auto">
       <div className="w-full display5B border-solid border-b-[1px] border-whtie pb-[15px]">
         <span>인사이드아웃 사회적 협동조합</span>
       </div>

--- a/apps/web/components/main/Header.tsx
+++ b/apps/web/components/main/Header.tsx
@@ -19,7 +19,7 @@ const Header = () => {
     setSelectedTab(tabName);
   };
   return (
-    <div className="w-[1440px] h-[94px] bg-primary10 ">
+    <div className="w-[1440px] h-[94px] bg-primary10 mx-auto">
       <div className="flex h-[37px]">
         <span className="px-[18.5px] py-[11.62px] ml-[128px] bg-white">
           <SfaclogLogo width="62" height="18" />

--- a/apps/web/components/main/HotLogCard.tsx
+++ b/apps/web/components/main/HotLogCard.tsx
@@ -2,6 +2,7 @@ import { Crown, UpArrowRed } from "@repo/ui/index";
 import React from "react";
 import { HotLogCardProps } from "../../types/hotLogCard";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 
 const HotLogCard: React.FC<HotLogCardProps> = ({
   currentRank,
@@ -13,8 +14,18 @@ const HotLogCard: React.FC<HotLogCardProps> = ({
   id,
   collectionId,
 }) => {
+  const router = useRouter();
+
+  // 게시물 클릭 시 상세 페이지로 이동
+  const goToDetailPage = () => {
+    router.push(`/log/${id}`);
+  };
+
   return (
-    <div className="flex min-w-[30.9rem] h-[250px] flex-col gap-y-[10px] ml-[2px] mb-[2px] z-10">
+    <div
+      className="flex min-w-[30.9rem] h-[250px] flex-col gap-y-[10px] ml-[2px] mb-[2px] z-10"
+      onClick={goToDetailPage}
+    >
       <div className="flex items-end justify-between w-full px-[0.63rem]">
         <div className="flex gap-x-[15px] items-end">
           <span className="display4 text-neutral80">{currentRank}위</span>

--- a/apps/web/components/main/LogCard.tsx
+++ b/apps/web/components/main/LogCard.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import CardBottom from "@repo/ui/cardBottom";
 import { Bookmark, Chat, Eyes, HeartFull } from "@repo/ui/index";
 import { LogCardProps } from "../../types/logcard";
+import { useRouter } from "next/navigation";
 
 const LogCard: React.FC<LogCardProps> = ({
   id,
@@ -17,6 +18,8 @@ const LogCard: React.FC<LogCardProps> = ({
   commentCount,
   collectionId,
 }) => {
+  const router = useRouter();
+
   const formatNumber = (count: number) => {
     if (count >= 1000) {
       const formattedCount = (count / 1000).toFixed(1);
@@ -24,8 +27,14 @@ const LogCard: React.FC<LogCardProps> = ({
     }
     return count.toString();
   };
+
+  // 게시물 클릭 시 상세 페이지로 이동
+  const goToDetailPage = () => {
+    router.push(`/log/${id}`);
+  };
+
   return (
-    <div>
+    <div onClick={goToDetailPage}>
       <Card className="w-[320px] h-[300px] rounded-radius15 border-solid border-[1px] border-[#cccccc]">
         <div
           className="h-[190px]"

--- a/apps/web/components/main/LogSection.tsx
+++ b/apps/web/components/main/LogSection.tsx
@@ -3,6 +3,7 @@ import React, { useState } from "react";
 import FilterTagList from "./FilterTagList";
 import FilterSort from "./FilterSort";
 import LogCardList from "./LogCardList";
+import NewLogButton from "./NewLogButton";
 
 const LogSection = () => {
   const [filteredTags, setFilteredTags] = useState<string[]>([]);
@@ -30,8 +31,9 @@ const LogSection = () => {
           filteredTags={filteredTags}
           onTagClick={handleTagClick}
         />
-        <div className="mt-[74px] mb-[25px]">
+        <div className="mt-[74px] mb-[25px] flex justify-between">
           <FilterSort onSortChange={handleSortChange} />
+          <NewLogButton />
         </div>
       </div>
       <LogCardList filteredTags={filteredTags} selectedSort={selectedSort} />

--- a/apps/web/components/main/NewLogButton.tsx
+++ b/apps/web/components/main/NewLogButton.tsx
@@ -1,0 +1,22 @@
+import { Plus } from "@repo/ui/index";
+import { useRouter } from "next/navigation";
+
+const NewLogButton = () => {
+  const router = useRouter();
+
+  // 게시물 클릭 시 상세 페이지로 이동
+  const goToNewLogPage = () => {
+    router.push(`/log`);
+  };
+
+  return (
+    <button
+      className="flex justify-center items-center w-[180px] h-[50px] bg-primary90 text-white rounded-radius5"
+      onClick={goToNewLogPage}
+    >
+      <Plus stroke="white" />새 로그 작성
+    </button>
+  );
+};
+
+export default NewLogButton;

--- a/apps/web/components/mypage/LogCard.tsx
+++ b/apps/web/components/mypage/LogCard.tsx
@@ -2,6 +2,7 @@
 
 import { Bookmark, Chat, Eyes, HeartFull } from "@repo/ui/index";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 
 import { useState } from "react";
 
@@ -10,6 +11,7 @@ import { useAppSelector } from "../../hooks/redux";
 import { LogCardProps } from "../../types/log";
 
 const LogCard = ({ log, method }: { log: LogCardProps; method: any }) => {
+  const router = useRouter();
   const {
     id,
     title,
@@ -26,11 +28,17 @@ const LogCard = ({ log, method }: { log: LogCardProps; method: any }) => {
   // 북마크한거
   const [isFavorite, setIsFavorite] = useState<boolean>(false);
 
-  const handleFavoriteButton = () => {
+  const handleFavoriteButton = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation(); // 북마크 버튼 클릭 시 이벤트 버블링 방지
     setIsFavorite((prev) => !prev);
   };
 
   const { setValue, getValues } = method;
+
+  // 게시물 클릭 시 상세 페이지로 이동
+  const goToDetailPage = () => {
+    router.push(`/log/${id}`);
+  };
 
   const handleClick = () => {
     setValue("log", id);
@@ -43,8 +51,9 @@ const LogCard = ({ log, method }: { log: LogCardProps; method: any }) => {
     <li
       key={id + title}
       className="relative w-[320px] h-[302px] rounded-[10px] overflow-hidden border border-solid border-neutral20 cursor-pointer"
+      onClick={goToDetailPage}
     >
-      <label className="h-full w-full" onClick={handleClick}>
+      <div className="h-full w-full" onClick={handleClick}>
         {/* isLogSelectSetting 대표로그 설정 클릭 여부 */}
         {selectState?.isSelectedLogPage ? (
           <div className="absolute top-[16px] right-[16px]">
@@ -112,7 +121,7 @@ const LogCard = ({ log, method }: { log: LogCardProps; method: any }) => {
             </div>
           </div>
         </div>
-      </label>
+      </div>
     </li>
   );
 };

--- a/apps/web/components/mypage/replies/ReplieCard.tsx
+++ b/apps/web/components/mypage/replies/ReplieCard.tsx
@@ -1,7 +1,11 @@
+"use client";
+
+import { useRouter } from "next/navigation";
 interface Reply {
   id: number;
   content: string;
   expand: any;
+  log: string;
 }
 
 interface ReplieCardProps {
@@ -10,12 +14,17 @@ interface ReplieCardProps {
 const ReplieCard = ({ repliesData }: ReplieCardProps) => {
   if (repliesData.length === 0) return null;
 
+  const router = useRouter();
+
   return (
     <>
-      {repliesData?.map((data) => (
+      {repliesData?.map((data, index) => (
         <div
           key={data.id}
           className="border border-primary90 flex flex-col w-full p-[25px] rounded-radius15"
+          onClick={() => {
+            router.push(`/log/${data.log}`);
+          }}
         >
           <div className="border-b border-neutral20 pb-[15px] mb-extraSmall3">
             <div className="flex gap-[10px]">

--- a/apps/web/components/mypage/savelog/SaveLog.tsx
+++ b/apps/web/components/mypage/savelog/SaveLog.tsx
@@ -1,13 +1,13 @@
-import React, { useEffect, useState } from "react";
 import Card from "@repo/ui/card";
-import CardTop from "@repo/ui/cardTop";
 import CardBottom from "@repo/ui/cardBottom";
+import CardTop from "@repo/ui/cardTop";
 import { Bookmark, BookmarkFull, Chat, Eyes, HeartFull } from "@repo/ui/index";
-import SaveLogkModal from "../SaveLogkModal";
-import { useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
+import PocketBase from "pocketbase";
+import { useEffect, useState } from "react";
 import { useAppDispatch, useAppSelector } from "../../../hooks/redux";
 import { setSavePage } from "../../../store/saveLogSlice";
-import PocketBase from "pocketbase";
+import SaveLogkModal from "../SaveLogkModal";
 
 const SaveLog = ({
   savelogItem,
@@ -18,6 +18,8 @@ const SaveLog = ({
   method: any;
   saveLogState: boolean;
 }) => {
+  const router = useRouter();
+
   const { setValue, getValues, watch } = method;
 
   const handleClick = () => {


### PR DESCRIPTION
<!--
1. 제목은 50자 이내
2. 장황하게 설명하지 않고 간단하게 기술
3. 과거 시제 사용 X
4. 명사형 어미 사용

* 제목양식
[태그] 제목 #이슈번호
태그 첫 글자는 대문자로
예시) [Feat] 로그인 기능 구현 #32

* 제목 태그 종류
[Feat] 새로운 기능 추가
[Fix] 버그 수정
[Docs] 문서 수정
[Style] 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
[Design] CSS 등 사용자 UI 디자인 변경
[Refactor] 코드 리팩토링
[Test] 테스트 코드, 리팩토링 테스트 코드 추가
[Chore] 빌드 업무 수정, 패키지 매니저 수정


* 작성 후 이슈, 라벨, 마일스톤 등 연결하기
* Assignees : 작업자
-->

## 작업사항

<!-- 작업한 내용 작성 -->

- 마이페이지 '내가 쓴 로그' 페이지에서의 게시물 카드 클릭 시 게시물 상세 페이지로 이동하게끔 하는 기능 구현
- 마이페이지 '내가 쓴 댓글' 페이지에서의 게시물 카드 클릭 시 게시물 상세 페이지로 이동하게끔 하는 기능 구현
- 메인 페이지 '오늘의 hot 로그' 컴포넌트에서의 카드 클릭시 게시물 상세 페이지로 이동하게끔 하는 기능 구현
- 메인 페이지 <LogSection /> 컴포넌트에서의 카드 클릭시 게시물 상세 페이지로 이동하게끔 하는 기능 구현
- 메인 페이지 '새 로그 작성' 버튼 컴포넌트 기능 구현 및 스타일링
- 메인 페이지 '새 로그 작성' 버튼 배치 및 스타일링

## 미리보기 및 사용방법

<!-- 미리보기 파일 첨부와 함께 사용 방법 작성. 이미지, 동영상 등 작업 내용을 확인할 수 있는 파일 첨부 -->
![Feb-13-2024 16-14-55](https://github.com/33-ohoh/33-ohoh/assets/69342971/c0d9645a-5ea0-44f1-b74c-f3ccdffe22f5)


## 기타

<!-- 필요한 경우 작성 -->
- 마이페이지 '내 저장 로그' 및 '최근 본 로그' 페이지에서의 로그 상세 페이지 이동 구현은 추후 작업 예정

## 작성일

<!-- 풀 리퀘스트 작성한 날짜 작성 yyyy.mm.dd -->

2024.02.13
